### PR TITLE
Upgrade Go to 1.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -y install nodejs bzip2
 RUN wget -qO- https://bootstrap.pypa.io/get-pip.py | python
 RUN pip install awscli
 
-RUN wget -qO- https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz | tar -xvz -C /usr/local
+RUN wget -qO- https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz | tar -xvz -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 RUN wget -qO- https://get.docker.com | sh


### PR DESCRIPTION
### What

Upgrade go to `1.7.4` to incorporate latest security updates.

### How to review

Build the image, run the container. Check the version of go is `1.7.4`.

### Who can review

Anyone but myself.

