### PR TITLE
add build monitor plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN usermod -aG docker jenkins
 
 USER jenkins
 
-RUN /usr/local/bin/install-plugins.sh docker-workflow github workflow-aggregator xvfb
+RUN /usr/local/bin/install-plugins.sh docker-workflow github workflow-aggregator xvfb build-monitor-plugin


### PR DESCRIPTION
### What

Add build monitor plugin to Jenkins.

### How to review

Build the image, run the container. Check that the `build-monitor-plugin` plugin is installed.

### Who can review

Anyone but myself.
