### PR TITLE
bump go to 1.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y install   \
 RUN wget -qO- https://bootstrap.pypa.io/get-pip.py | python
 RUN pip install awscli
 
-RUN wget -qO- https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz | tar -xvz -C /usr/local
+RUN wget -qO- https://storage.googleapis.com/golang/go1.9.3.linux-amd64.tar.gz | tar -xvz -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 RUN git clone https://github.com/awslabs/amazon-ecr-credential-helper \


### PR DESCRIPTION
### What

Upgrade Go to version 1.9.3.

### How to review

Build the image. Run the container. Check Go version is 1.9.3 (`go version`).

### Who can review

Anyone but myself.
