### PR TITLE
feature/go-1.10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y install   \
 RUN wget -qO- https://bootstrap.pypa.io/get-pip.py | python
 RUN pip install awscli
 
-RUN wget -qO- https://storage.googleapis.com/golang/go1.9.3.linux-amd64.tar.gz | tar -xvz -C /usr/local
+RUN wget -qO- https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz | tar -xvz -C /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 RUN git clone https://github.com/awslabs/amazon-ecr-credential-helper \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ USER root
 
 RUN wget -qO- https://deb.nodesource.com/setup_8.x | bash
 
-RUN echo deb https://dl.bintray.com/sbt/debian / > /etc/apt/sources.list.d/sbt.list
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
-
 RUN echo deb http://dl.google.com/linux/chrome/deb/ stable main > /etc/apt/sources.list.d/google-chrome.list
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 
@@ -17,7 +14,6 @@ RUN apt-get -y install   \
     google-chrome-stable \
     make                 \
     nodejs               \
-    sbt                  \
     xvfb
 
 RUN wget -qO- https://bootstrap.pypa.io/get-pip.py | python


### PR DESCRIPTION
### What

Bump Go to latest stable, remove SBT.

### How to review

* Code review
* Build the image (`docker build -t jenkins `)
* Verify Go `1.10.2` is installed (`docker run jenkins go version`)
* Verify sbt is missing (`docker run jenkins sbt`)

### Who can review

Not me.
